### PR TITLE
Align Maven coordinates with other eXist-db EXPath modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
         <relativePath/>
     </parent>
 
-    <groupId>org.exist</groupId>
-    <artifactId>mongrel</artifactId>
+    <groupId>org.exist-db.xquery.extensions.expath</groupId>
+    <artifactId>expath-mongodb-module</artifactId>
     <version>0.6.4-SNAPSHOT</version>
 
     <name>Mongrel MongoDB and GridFS driver</name>


### PR DESCRIPTION
For example of existing coordinates for EXPath modules with eXist-db see:

1. https://github.com/eXist-db/expath-file-module/blob/master/pom.xml#L14
2. https://github.com/eXist-db/expath-bin-module/blob/master/pom.xml#L13

Really this module should follow the same scheme.